### PR TITLE
Click-to-see-path

### DIFF
--- a/app/css/partials/board.css
+++ b/app/css/partials/board.css
@@ -26,6 +26,32 @@ input#message:focus {
   border: 2px solid #73ad21;
   padding: 2px;
 }
+.code-popup {
+  visibility: hidden;
+  display: inline-block;
+  width: 5em;
+  text-align: center;
+  background: black;
+  border:solid 2px #73ad21;
+  border-radius: 6px;
+  position: absolute;
+  bottom: -1em;
+  z-index: 1;
+  color: #b44f47;
+  padding: .2em;
+}
+.encoded-token:hover .code-popup {
+  visibility: visible;
+}
+
+.highlight-token {
+  color: #b44f47;
+}
+
+.encoded-token {
+  cursor: pointer;
+  position: relative;
+}
 
 #board {
   height: 800px;

--- a/app/css/partials/message.css
+++ b/app/css/partials/message.css
@@ -78,6 +78,7 @@ input[type=text] {
   margin-top: 3px;
   /* color: white; */
   color: #60ff60;
+  font-family: 'Courier New', Courier, monospace;
   font-size: larger;
   font-weight: 600;
 }

--- a/app/css/partials/message.css
+++ b/app/css/partials/message.css
@@ -70,8 +70,28 @@
   float: left;
 }
 
+input[type=text] {
+  width: 80%;
+}
+
 #code {
   margin-top: 3px;
+  /* color: white; */
+  color: #60ff60;
+  font-size: larger;
+  font-weight: 600;
+}
+
+.super-shadow {
+  /* text-shadow: 0 0 10px rgba(255,255,255,1) , 0 0 20px rgba(255,255,255,1) , 0 -6px 30px rgba(255,255,255,1) , 0 0 40px #ff00de , 0 0 70px #ff00de , 0 0 80px #ff00de , 0 0 100px #ff00de */
+  text-shadow:  0px 0px 5px rgba(255, 255, 255, 1), 
+                0px 0px 7px rgba(255, 255, 255, .5), 
+                0px 0px 9px rgba(255, 255, 255, .5),
+                0px 0px 12px rgba(73, 255, 24, .5),
+                0px 0px 15px rgba(73, 255, 24, .5),
+                0px 0px 20px rgba(73, 255, 24, .5),
+                0px 0px 25px rgba(73, 255, 24, .5),
+                0px 0px 30px rgba(73, 255, 24, .5);
 }
 
 /* decoder css */

--- a/app/write-message.js
+++ b/app/write-message.js
@@ -193,6 +193,12 @@ const onReady = function () {
     } else {
       console.log("Error changing new digit.");
     }
+    // super-shadow for aliens!
+    if(DIGITS[0] === "👾"){
+      $("#code").addClass("super-shadow");
+    } else {
+      $("#code").removeClass("super-shadow");
+    }
   })
 };
 

--- a/app/write-message.js
+++ b/app/write-message.js
@@ -90,7 +90,11 @@ function setUpFromUrl() {
     console.log(message);
     $("#message").val(message);
     // $("#message").val(board.decodeMessage(encodedmessage).join(""));
-
+    if(DIGITS[0] === "👾"){
+      $("#code").addClass("super-shadow");
+    } else {
+      $("#code").removeClass("super-shadow");
+    }
     resetMessage(message);
   }
 }
@@ -188,8 +192,7 @@ const onReady = function () {
   $(".digit-select").on("click", function(event) {
     const newDigits = $(this).data("digit");
     if(newDigits){
-      DIGITS = [...newDigits];
-      resetMessage();
+      changeDigitSystem([...newDigits])
     } else {
       console.log("Error changing new digit.");
     }

--- a/app/write-message.js
+++ b/app/write-message.js
@@ -108,7 +108,8 @@ function resetMessage(message) {
   const digitsStr = DIGITS[0] + DIGITS[1];
   const displayMessage = convertDigits(code, INTERNAL_DIGITS, DIGITS);
   const displayMessageNoSpaces = displayMessage.split(" ").join("");
-  $("#code").text(displayMessage);
+  // $("#code").text(displayMessage);
+  setupDisplay(code);
   const encodedmessage = code.split(" ").join(""); // remove spaces
   currentEncodedMessage = encodedmessage;
   const bitLength = currentEncodedMessage.length || 0;
@@ -202,7 +203,23 @@ const onReady = function () {
     } else {
       $("#code").removeClass("super-shadow");
     }
-  })
+  });
+  $("#code").on("click", function(event) {
+    if(event.target && $(event.target).data("code")) {
+      const code = $(event.target).data("code")
+      console.log(code);
+      const decodedTiles = board.decodeMessage(code, true);
+      console.log(decodedTiles);
+      if(decodedTiles) {
+        $(".encoded-token").removeClass("highlight-token");
+        $(event.target).addClass("highlight-token");
+        const letter = decodedTiles[0].l;
+        const tile = decodedTiles[0];
+        board.setCurrNodeTile(tile);
+        repaint(board);
+      }
+    } 
+  });
 };
 
 const resetCopyButtonText = function(){
@@ -212,6 +229,21 @@ const resetCopyButtonText = function(){
 const changeDigitSystem = function(digits) {
   DIGITS = digits;
   resetMessage();
+}
+
+function setupDisplay(encodedMessageWithSpaces) {
+  let tokens = encodedMessageWithSpaces.split(" ");
+  let message = board.decodeMessage(tokens.join(""));
+  let elms = [];
+  for(let i=0; i<tokens.length; i++) {
+    const internalCode = tokens[i];
+    const encodedLetter = convertDigits(internalCode, INTERNAL_DIGITS, DIGITS);
+    elms.push(`<span
+      class="encoded-token"
+      data-code="${internalCode}"> ${encodedLetter} <span class="code-popup">${message[i]}:  ${encodedLetter}</span></span>`);
+  }
+  console.log(elms.join(""))
+  $("#code").html(elms.join(""));
 }
 
 function convertDigits(encodedMessage, fromDigits, toDigits) {

--- a/letter-tree.js
+++ b/letter-tree.js
@@ -322,7 +322,7 @@ class LetterTree {
     return message.map((letter) => letterMap.get(letter));
   }
 
-  decodeMessage(code) {
+  decodeMessage(code, includeTiles) {
     let n = 1;
     let message = [];
     //let i = 0;
@@ -338,7 +338,11 @@ class LetterTree {
         const letterTileArr = this.tiles
           .asFlatArray()
           .filter((t) => t.p === "A" && t.n === n);
-        message.push(letterTileArr[0].l);
+        if(!includeTiles) {
+          message.push(letterTileArr[0].l);
+        } else {
+          message.push(letterTileArr[0]);
+        }
         n = 1; // start at top
       }
     }


### PR DESCRIPTION
This adds a click listener to the encoded token display, so the creator of a message can freely inspect each token and its encoding. 

Also adds a tooltip popup on the encoded display for the writer.